### PR TITLE
feat: Skip download if feather file exists

### DIFF
--- a/src/binance_downloader/downloader.py
+++ b/src/binance_downloader/downloader.py
@@ -403,9 +403,12 @@ class BinanceDataDownloader:
                                     final_csv_path = temp_task.output_path.with_suffix(
                                         ".csv"
                                     )
-                                    if final_csv_path.exists():
+                                    final_feather_path = temp_task.output_path.with_suffix(
+                                        ".feather"
+                                    )
+                                    if final_csv_path.exists() or final_feather_path.exists():
                                         self.logger.debug(
-                                            f"Skipping existing file: {final_csv_path}"
+                                            f"Skipping existing file (CSV or Feather): {final_csv_path.stem}"
                                         )
                                         continue  # 如果存在，就跳過這個迴圈，不建立任務
 
@@ -423,9 +426,12 @@ class BinanceDataDownloader:
                                 final_csv_path = temp_task.output_path.with_suffix(
                                     ".csv"
                                 )
-                                if final_csv_path.exists():
+                                final_feather_path = temp_task.output_path.with_suffix(
+                                    ".feather"
+                                )
+                                if final_csv_path.exists() or final_feather_path.exists():
                                     self.logger.debug(
-                                        f"Skipping existing file: {final_csv_path}"
+                                        f"Skipping existing file (CSV or Feather): {final_csv_path.stem}"
                                     )
                                     continue
 


### PR DESCRIPTION
I modified the BinanceDataDownloader to check for the existence of a .feather file as a condition for skipping downloads, in addition to the existing .csv file check.

- If either a .csv or a .feather file corresponding to a potential download task exists, that download task is skipped.
- The log message for skipped files has been updated to indicate that either a CSV or Feather file was found.
- I added a new unit test `test_download_data_skip_existing_files` to `tests/test_downloader.py` to specifically verify this new skipping behavior, ensuring that:
    - Downloads are skipped if a .csv file exists.
    - Downloads are skipped if a .feather file exists.
    - Downloads proceed if neither file exists.
    - Correct log messages are produced for skipped files.